### PR TITLE
Add Linux examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ windows {
     // Generic parameter value for Windows build
     icon = "icons/icons.ico"
 }
+
+linux
+    // Generic parameter values for Linux build
+    icon = "icons/icons.png"
+    installDir = "/usr" // Prefix
+}
 ```
 
 ### Parameters


### PR DESCRIPTION
I added "installDir" to help clue people in that "installDir" is actually the prefix on Linux.