### PR TITLE
Bug Fix

### DIFF
--- a/src/main/java/org/panteleyev/jpackage/JPackageTask.java
+++ b/src/main/java/org/panteleyev/jpackage/JPackageTask.java
@@ -1002,6 +1002,12 @@ public class JPackageTask extends DefaultTask {
 
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
                 String line = reader.readLine();
+                String prevLine = line;
+                while(line != null) {
+                    prevLine = line;
+                    line = reader.readLine();
+                }
+                line = prevLine;
                 if (line != null) {
                     String[] parts = line.split("\\.");
                     result = Integer.parseInt(parts[0]);


### PR DESCRIPTION
When the output of the jpackage --version command contains a message on the first line, the version is unable to be parsed. This fix reads lines and attempts to process the last line read.